### PR TITLE
Update service worker cache to reflect recent pool image update

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'grappa-guest-guide-v33';
+const CACHE_NAME = 'grappa-guest-guide-v34';
 
 // A comprehensive list of assets to cache for a full offline experience.
 const URLS_TO_CACHE = [
@@ -23,7 +23,7 @@ const URLS_TO_CACHE = [
   'https://i.imgur.com/MBYTWps.png', // Logistics info
   'https://i.imgur.com/ChMRT7d.jpg', // Sushi menu
   './Grocery_hours.jpg',
-  './swiming_pool_instructions.png?v=4',
+  './swiming_pool_instructions.png?v=6',
   'https://i.imgur.com/5vg5NXj.png',  // Spa info (fixed URL)
   
   // Downloadable Trail Files - Caching these ensures guests can access them without a connection.


### PR DESCRIPTION
This addresses the issue where users were still seeing the old swimming pool image on their devices due to aggressive caching by the service worker. Bumping the cache version forces clients to clear their cache and fetch the newest assets.

---
*PR created automatically by Jules for task [17390350785399832792](https://jules.google.com/task/17390350785399832792) started by @rielOosh*